### PR TITLE
Restict unique token to active ones

### DIFF
--- a/Repository/DoctrineORMTokenRepository.php
+++ b/Repository/DoctrineORMTokenRepository.php
@@ -66,13 +66,21 @@ class DoctrineORMTokenRepository implements TokenRepositoryInterface
      */
     public function findExisting($userClass, $userId, $purpose)
     {
-        return $this->repository->findOneBy(
+        $token = $this->repository->findOneBy(
             [
                 'userClass' => $userClass,
                 'userId' => $userId,
                 'purpose' => $purpose,
             ]
         );
+        if (!$token instanceof Token) {
+            return null;
+        }
+        if ($token->isConsumed() || $token->isExpired()) {
+            return null;
+        }
+
+        return $token;
     }
 
     /**

--- a/Repository/TokenRepositoryInterface.php
+++ b/Repository/TokenRepositoryInterface.php
@@ -29,7 +29,7 @@ interface TokenRepositoryInterface
     public function get($value, $purpose);
 
     /**
-     * Find existing token for user and purpose.
+     * Find existing and active token for user and purpose.
      *
      * @param string $userClass The user class
      * @param string $userId    The user identifier

--- a/Resources/doc/2-configuration.md
+++ b/Resources/doc/2-configuration.md
@@ -16,6 +16,7 @@ Each token can have following options :
 - `duration` : a valid [`DateTime::modify`](https://php.net/manual/datetime.modify.php) argument that represent the validity duration for tokens of this type
 - `usages` : an integer that represent the number of allowed usages for tokens of this type
 - `keep` : a valid [`DateTime::modify`](https://php.net/manual/datetime.modify.php) argument that represent the keep duration for tokens of this type
+- `unique` : a boolean that indicates whether or not the token must be unique per user
 
 Default values fallback to :
 
@@ -23,6 +24,7 @@ Default values fallback to :
 - `duration` : `+2 days`
 - `usages` : `1`
 - `keep` : `+1 month`
+- `unique` : `false`
 
 
 ---


### PR DESCRIPTION
Expired & consumed tokens should not be considered as existing when it is matter of checking that a token already exists or not.